### PR TITLE
Disable Quill toolbar color option

### DIFF
--- a/config/twill/toolbar_options.php
+++ b/config/twill/toolbar_options.php
@@ -4,7 +4,6 @@ return [
 
     [ 'header' => [2, 3, false] ],
     'bold', 'italic', 'underline', 'strike', 'link', 'blockquote',
-    [ 'color' => [] ],
     [ 'list' => 'ordered' ],
     [ 'list' => 'bullet' ],
     [ 'script' => 'sub' ],


### PR DESCRIPTION
This PR removes the Quill toolbar color option in an attempt to fix #28.

It seems the error only occurs if quill tries to process the example content's colors.