### PR TITLE
Fix byproducts block layout

### DIFF
--- a/resources/views/site/blocks/byproducts.blade.php
+++ b/resources/views/site/blocks/byproducts.blade.php
@@ -6,6 +6,12 @@
     $profilePage = $profilePage ?? false;
 @endphp
 
-@foreach ($byproducts as $item)
-    @include('site.byproducts.loop')
-@endforeach
+<section class="section block block-byproducts">
+    <div class="container">
+        <div class="columns">
+            @foreach ($byproducts as $item)
+                @include('site.byproducts.loop')
+            @endforeach
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
This PR reverts the changes made to `resources/views/site/blocks/byproducts.blade.php` in #92, which were breaking the layout.

![screenshot](https://user-images.githubusercontent.com/1569300/90632218-f9227200-e21b-11ea-8768-2943f9d667b7.png)
